### PR TITLE
Switch from Keras to tf.keras

### DIFF
--- a/deepmass/cnn_keras.py
+++ b/deepmass/cnn_keras.py
@@ -1,12 +1,12 @@
 
 
 import numpy as np
-from keras import backend as K
-from keras.layers import Input, Dropout, Conv2D, MaxPooling2D, UpSampling2D, add, BatchNormalization, Conv2DTranspose
-from keras.layers import concatenate, AveragePooling2D
-from keras.models import Model
-from keras.callbacks import Callback
-from keras.optimizers import Adam
+import tensorflow.keras as keras
+from tensorflow.keras.layers import Input, Dropout, Conv2D, MaxPooling2D, UpSampling2D, add, BatchNormalization, Conv2DTranspose
+from tensorflow.keras.layers import concatenate, AveragePooling2D
+from tensorflow.keras.models import Model
+from tensorflow.keras.callbacks import Callback
+from tensorflow.keras.optimizers import Adam
 
 
 
@@ -146,6 +146,3 @@ class UnetlikeBaseline:
             unet.compile(optimizer=Adam(lr=self.learning_rate), loss='mse')
 
         return unet
-
-
-

--- a/notebooks/Apply_trained_DeepMass.ipynb
+++ b/notebooks/Apply_trained_DeepMass.ipynb
@@ -24,7 +24,7 @@
     "%matplotlib inline\n",
     "import numpy as np\n",
     "import time\n",
-    "from keras.models import load_model\n",
+    "from tensorflow.keras.models import load_model\n",
     "import os, sys\n",
     "import scipy.ndimage as ndimage\n",
     "from scipy.stats import pearsonr\n",
@@ -252,7 +252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@NiallJeffrey let me know what you think about these changes but  nowadays, it's more convenient to directly use the keras module included with tensorfllow.